### PR TITLE
Fix compatibility with older Python versions

### DIFF
--- a/circuitpython_mocks/_mixins.py
+++ b/circuitpython_mocks/_mixins.py
@@ -1,5 +1,11 @@
 from collections import deque
-from typing import Self, Deque, Union, TYPE_CHECKING
+from typing import Deque, Union, TYPE_CHECKING
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 
 if TYPE_CHECKING:
     from circuitpython_mocks.busio.operations import (

--- a/circuitpython_mocks/_mixins.py
+++ b/circuitpython_mocks/_mixins.py
@@ -3,7 +3,7 @@ from typing import Deque, Union, TYPE_CHECKING
 
 try:
     from typing import Self
-except ImportError:
+except ImportError:  # pragma: no cover
     from typing_extensions import Self
 
 

--- a/circuitpython_mocks/busio/__init__.py
+++ b/circuitpython_mocks/busio/__init__.py
@@ -20,7 +20,7 @@
 
 from enum import Enum, auto
 import sys
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import circuitpython_typing
 
@@ -189,8 +189,8 @@ class SPI(Expecting, Lockable):
     def __init__(
         self,
         clock: Pin,
-        MOSI: Pin | None = None,
-        MISO: Pin | None = None,
+        MOSI: Union[Pin, None] = None,
+        MISO: Union[Pin, None] = None,
         half_duplex: bool = False,
     ):
         """A class to mock :external:py:class:`busio.SPI`."""
@@ -297,16 +297,16 @@ class UART(Expecting, Lockable):
 
     def __init__(
         self,
-        tx: Pin | None = None,
-        rx: Pin | None = None,
+        tx: Union[Pin, None] = None,
+        rx: Union[Pin, None] = None,
         *,
-        rts: Pin | None = None,
-        cts: Pin | None = None,
-        rs485_dir: Pin | None = None,
+        rts: Union[Pin, None] = None,
+        cts: Union[Pin, None] = None,
+        rs485_dir: Union[Pin, None] = None,
         rs485_invert: bool = False,
         baudrate: int = 9600,
         bits: int = 8,
-        parity: Parity | None = None,
+        parity: Union[Parity, None] = None,
         stop: int = 1,
         timeout: float = 1,
         receiver_buffer_size: int = 64,
@@ -315,7 +315,7 @@ class UART(Expecting, Lockable):
         self._timeout = timeout
         super().__init__()
 
-    def read(self, nbytes: int | None = None) -> Optional[bytes]:
+    def read(self, nbytes: Union[int, None] = None) -> Optional[bytes]:
         """A function that mocks :external:py:meth:`busio.UART.read()`.
 
         .. mock-expects::
@@ -362,7 +362,7 @@ class UART(Expecting, Lockable):
         op.assert_response(buf, 0, len_buf)
         return None if buf else bytes(buf)
 
-    def write(self, buf: circuitpython_typing.ReadableBuffer) -> int | None:
+    def write(self, buf: circuitpython_typing.ReadableBuffer) -> Union[int, None]:
         """A function that mocks :external:py:meth:`busio.UART.write()`.
 
         .. mock-expects::

--- a/circuitpython_mocks/digitalio/operations.py
+++ b/circuitpython_mocks/digitalio/operations.py
@@ -1,8 +1,11 @@
+from typing import Union
+
+
 class _State:
-    def __init__(self, state: bool | int) -> None:
+    def __init__(self, state: Union[bool, int]) -> None:
         self.state = bool(state)
 
-    def assert_state(self, value: bool | int):
+    def assert_state(self, value: Union[bool, int]):
         assert self.state is bool(
             value
         ), "Expected pin state does not match given pin state"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 adafruit-circuitpython-typing
 pytest
+typing-extensions~=4.0


### PR DESCRIPTION
* add a fallback to `typing_extensions` when importing `Self`
* use pre-3.10 `Union` types

Hopefully this should fix #17 (at least for 3.9+)